### PR TITLE
Feat: Add config for pyaedt

### DIFF
--- a/src/ansys/tools/meilisearch/create_indexes.py
+++ b/src/ansys/tools/meilisearch/create_indexes.py
@@ -50,7 +50,9 @@ def get_sphinx_urls(urls):
     return {repo: url for repo, url in urls.items() if is_sphinx(url)}
 
 
-def create_sphinx_indexes(sphinx_urls, meilisearch_host_url=None, meilisearch_api_key=None):
+def create_sphinx_indexes(
+    sphinx_urls, meilisearch_host_url=None, meilisearch_api_key=None, is_pyaedt=False
+):
     """Create an index for each public GitHub page that uses Sphinx.
 
     The created ``index_uid`` will match ``<repo>-sphinx-docs`` with a ``'-'``
@@ -80,7 +82,7 @@ def create_sphinx_indexes(sphinx_urls, meilisearch_host_url=None, meilisearch_ap
         index_uid = f"{repo}-sphinx-docs"
         temp_index_uid = f"temp-{repo}-sphinx-docs"
         web_scraper = WebScraper(meilisearch_host_url, meilisearch_api_key)
-        web_scraper.scrape_url(url, temp_index_uid, template="sphinx")
+        web_scraper.scrape_url(url, temp_index_uid, pyaedt=is_pyaedt)
         client = MeilisearchClient(meilisearch_host_url, meilisearch_api_key)
         document_utils = MeilisearchUtils(client)
         stats = client.client.get_all_stats()
@@ -88,5 +90,5 @@ def create_sphinx_indexes(sphinx_urls, meilisearch_host_url=None, meilisearch_ap
         if not index_uid in index_uids:
             response = client.client.create_index(index_uid, {"primaryKey": "objectID"})
             document_utils._wait_task(response.task_uid)
-        client.client.swap_indexes([{"indexes": [temp_index_uid, index_uid]}])
+        swap_response = client.client.swap_indexes([{"indexes": [temp_index_uid, index_uid]}])
         client.client.index(temp_index_uid).delete()

--- a/src/ansys/tools/meilisearch/scrapper.py
+++ b/src/ansys/tools/meilisearch/scrapper.py
@@ -123,7 +123,7 @@ class WebScraper(BaseClient):
         if response.status_code != 200:
             raise RuntimeError(f'Url "{url}" returned status code {response.status_code}')
 
-    def scrape_url(self, url, index_uid, template=None, verbose=False):
+    def scrape_url(self, url, index_uid, template=None, verbose=False, pyaedt=False):
         """For a single given URL, scrape it using the active Meilisearch host.
 
         This will generate a single index_uid for a single url.
@@ -145,7 +145,7 @@ class WebScraper(BaseClient):
             The number of hits from the URL.
         """
         self._check_url(url)
-        template = get_template(url) if template is None else template
+        template = get_template(url, pyaedt) if template is None else template
         temp_config_file = self._load_and_render_template(url, template, index_uid)
         output = self._scrape_url_command(temp_config_file)
         n_hits = self._parse_output(output)

--- a/src/ansys/tools/meilisearch/templates/__init__.py
+++ b/src/ansys/tools/meilisearch/templates/__init__.py
@@ -8,6 +8,7 @@ from jinja2 import Template
 # Declare the fundamental paths of the theme
 DEFAULT_TEMPLATE = pathlib.Path(__file__).parent.resolve() / "default.json"
 SPHINX_PYDATA_TEMPLATE = pathlib.Path(__file__).parent.resolve() / "sphinx_pydata.json"
+SPHINX_PYAEDT_TEMPLATE = pathlib.Path(__file__).parent.resolve() / "pyaedt_sphinx.json"
 
 
 def render_template(
@@ -41,7 +42,12 @@ def render_template(
         If any of the URLs do not start with "https://".
 
     """
-    template_path = SPHINX_PYDATA_TEMPLATE if template == "sphinx_pydata" else DEFAULT_TEMPLATE
+    if template == "sphinx_pyaedt":
+        template_path = SPHINX_PYAEDT_TEMPLATE
+    elif template == "sphinx_pydata":
+        template_path = SPHINX_PYDATA_TEMPLATE
+    else:
+        template_path = DEFAULT_TEMPLATE
 
     if not template_path.exists():
         raise FileNotFoundError(f"Unable to locate a template at {template_path}")

--- a/src/ansys/tools/meilisearch/templates/pyaedt_sphinx.json
+++ b/src/ansys/tools/meilisearch/templates/pyaedt_sphinx.json
@@ -1,0 +1,22 @@
+{
+    "index_uid": "{{ index_uid }}",
+    "start_urls": ["https://aedt.docs.pyansys.com/version/stable/",
+        "https://aedt.docs.pyansys.com/version/dev/"],
+    "stop_urls": ["/_sources", "/_downloads", "/_static", "/_images", "/.doctree",
+        "https://aedt.docs.pyansys.com/version/stable/EDBAPI/",
+        "https://aedt.docs.pyansys.com/version/dev/EDBAPI/"],
+    "selectors": {
+        "lvl0": {
+            "selector": "navbar-item",
+	    "global": true,
+            "default_value": "Documentation"
+        },
+        "lvl1": ".bd-content h1",
+        "lvl2": ".bd-content h2",
+        "lvl3": ".bd-content h3",
+        "lvl4": ".bd-content h4",
+        "lvl5": ".bd-content h5",
+        "lvl6": ".bd-content h6",
+        "text": "p"
+    }
+}

--- a/src/ansys/tools/meilisearch/templates/utils.py
+++ b/src/ansys/tools/meilisearch/templates/utils.py
@@ -4,7 +4,7 @@ import re
 import requests
 
 
-def get_template(url):
+def get_template(url: str, pyaedt: bool = False) -> str:
     """
     Determine the template name for the given URL.
 
@@ -13,12 +13,17 @@ def get_template(url):
     url : str
         The URL of the web page to check.
 
+    pyaedt : bool, optional
+        If True, the function uses the "sphinx_pydata" template for Sphinx pages,
+        otherwise it uses the "default" template. Default is False.
+
     Returns
     -------
     str
-        The name of the template to use for the page, either "sphinx" if the
-        page was built using Sphinx or "default" otherwise.
+        The name of the template to use for the page.
     """
+    if pyaedt:
+        return "sphinx_pyaedt" if is_sphinx(url) else "default"
     return "sphinx_pydata" if is_sphinx(url) else "default"
 
 

--- a/src/ansys/tools/meilisearch/utils.py
+++ b/src/ansys/tools/meilisearch/utils.py
@@ -62,7 +62,7 @@ class MeilisearchUtils:
 
         return documents
 
-    def _wait_task(self, task_uid: int, timeout: float = 10.0) -> None:
+    def _wait_task(self, task_uid: int, timeout: float = 20.0) -> None:
         """
         Wait until a task is complete.
 
@@ -73,7 +73,7 @@ class MeilisearchUtils:
         task_uid : int
             Task UID.
         timeout : float
-            Timeout value in seconds. Defaults to 10.0.
+            Timeout value in seconds. Defaults to 20.0.
 
         Raises
         ------
@@ -95,6 +95,8 @@ class MeilisearchUtils:
                     msg = json.dumps(jresp, indent=2)
                     raise RuntimeError(f"Task failed:\n\n{msg}")
             elif jresp["status"] == "succeeded":
+                break
+            elif jresp["status"] == "enqueued":
                 break
             else:
                 time.sleep(1)


### PR DESCRIPTION
In Pyaedt, there are two different APIs - EDB API and AEDT API - and the developers want to distinguish between the two in the documentation by scraping them into separate indexes. To achieve this, a new configuration was created specifically for Pyaedt as the docs should scrap as 2 different indexes. 