### PR TITLE
chore: protect minor bumps from pymeilisearch-scraper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jinja2>=3.1.2",
     "meilisearch>=0.24.0",
     "click>=8",
-    "pymeilisearch-scraper>=0.2.3",
+    "pymeilisearch-scraper>=0.2.3,<3",
     "pyOpenSSL>=23.2.0",
     "cryptography>=41.0.4",
 ]


### PR DESCRIPTION
We should merge this and do a new patch release before releasing any minor here: https://github.com/ansys/pymeilisearch-scraper/pull/18#issuecomment-2136722793